### PR TITLE
Fixed use state data for recent modules instead of config json.

### DIFF
--- a/config/module_filter.settings.json
+++ b/config/module_filter.settings.json
@@ -1,7 +1,6 @@
 {
     "_config_name": "module_filter.settings",
     "_config_static": true,
-    "recent_modules": [],
     "set_focus": 1,
     "use_tabs": 1,
     "count_enabled": 1,

--- a/module_filter.install
+++ b/module_filter.install
@@ -83,3 +83,18 @@ function module_filter_update_1001() {
     update_variable_del('module_filter_recent_modules');
   }
 }
+
+/**
+ * Migrate 'recent_modules' from configuration to state data.
+ */
+function module_filter_update_1002() {
+  $config = config('module_filter.settings');
+  $recent_modules = $config->get('recent_modules');
+
+  if (!empty($recent_modules) && is_array($recent_modules)) {
+    state_set('module_filter_recent_modules', $recent_modules);
+  }
+
+  $config->clear('recent_modules');
+  $config->save();
+}

--- a/module_filter.module
+++ b/module_filter.module
@@ -287,8 +287,7 @@ function module_filter_system_modules_submit_redirect($form, &$form_state) {
  * Form submission handler to track recently enabled/disabled modules
  */
 function module_filter_system_modules_submit_recent($form, &$form_state) {
-  $config = config('module_filter.settings');
-  $recent_modules = $config->get('recent_modules');
+  $recent_modules = state_get('module_filter_recent_modules', array());
 
   foreach ($form_state['values']['modules'] as $package => $modules) {
     foreach ($modules as $key => $module) {
@@ -298,9 +297,7 @@ function module_filter_system_modules_submit_recent($form, &$form_state) {
     }
   }
 
-  $config->set('recent_modules', $recent_modules);
-
-  $config->save();
+  state_set('module_filter_recent_modules', $recent_modules);
   backdrop_set_message(t('Recently enabled/disabled modules saved.'));
 }
 

--- a/module_filter.theme.inc
+++ b/module_filter.theme.inc
@@ -49,13 +49,10 @@ function theme_module_filter_system_modules_tabs($variables) {
   $enabled['all'] = array();
 
   if ($config->get('track_recent_modules')) {
-    $recent_modules = $config->get('recent_modules');
-    if (!is_array($recent_modules)) {
-      $recent_modules = array();
-    }
+    $recent_modules = state_get('module_filter_recent_modules', array());
     $recent_modules = array_filter($recent_modules, 'module_filter_recent_filter');
     // Save the filtered results.
-    $config->set('recent_modules', $recent_modules);
+    state_set('module_filter_recent_modules', $recent_modules);
 
     $package_ids[] = 'recent';
     $enabled['recent'] = array();


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/module_filter/issues/29
